### PR TITLE
사용자 북마크 기능 구현 및 Swagger 문서 개선

### DIFF
--- a/src/main/java/com/univ/memoir/MemoirApplication.java
+++ b/src/main/java/com/univ/memoir/MemoirApplication.java
@@ -1,8 +1,16 @@
 package com.univ.memoir;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@OpenAPIDefinition(
+		servers = {
+				@Server(url = "https://memoir.asia", description = "Production server"),
+				@Server(url = "http://localhost:8888", description = "Local development server")
+		}
+)
 @SpringBootApplication
 public class MemoirApplication {
 

--- a/src/main/java/com/univ/memoir/api/controller/BookmarkController.java
+++ b/src/main/java/com/univ/memoir/api/controller/BookmarkController.java
@@ -1,0 +1,58 @@
+package com.univ.memoir.api.controller;
+
+import com.univ.memoir.api.dto.req.BookmarkRequestDto;
+import com.univ.memoir.api.dto.req.BookmarkUpdateRequestDto;
+import com.univ.memoir.api.exception.responses.SuccessResponse;
+import com.univ.memoir.core.service.BookmarkService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/bookmarks")
+@Tag(name = "즐겨찾기", description = "즐겨찾기 관련 API")
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @GetMapping
+    @Operation(summary = "즐겨찾기 조회", description = "사용자의 즐겨찾기 목록을 조회합니다.")
+    public ResponseEntity<SuccessResponse<Set<String>>> getBookmarks(
+            @RequestHeader(name = "Authorization") String accessToken) {
+        SuccessResponse<Set<String>> response = bookmarkService.getBookmarks(accessToken);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @PostMapping
+    @Operation(summary = "즐겨찾기 추가", description = "즐겨찾기를 추가합니다.")
+    public ResponseEntity<SuccessResponse<String>> addBookmark(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody BookmarkRequestDto requestDto) {
+        SuccessResponse<String> response = bookmarkService.addBookmark(accessToken, requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping
+    @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기를 삭제합니다.")
+    public ResponseEntity<SuccessResponse<String>> removeBookmark(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody BookmarkRequestDto requestDto) {
+        SuccessResponse<String> response = bookmarkService.removeBookmark(accessToken, requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping
+    @Operation(summary = "즐겨찾기 수정", description = "즐겨찾기를 수정합니다.")
+    public ResponseEntity<SuccessResponse<String>> updateBookmark(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestBody BookmarkUpdateRequestDto requestDto) {
+        SuccessResponse<String> response = bookmarkService.updateBookmark(accessToken, requestDto);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/univ/memoir/api/controller/DailySummaryController.java
+++ b/src/main/java/com/univ/memoir/api/controller/DailySummaryController.java
@@ -4,6 +4,8 @@ import com.univ.memoir.api.dto.req.time.TimeAnalysisRequest;
 import com.univ.memoir.api.exception.codes.SuccessCode;
 import com.univ.memoir.api.exception.responses.SuccessResponse;
 import com.univ.memoir.core.service.DailySummaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,7 @@ import reactor.core.publisher.Mono;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "일일 요약", description = "일일 요약 관련 API")
 public class DailySummaryController {
 
 	private final DailySummaryService dailySummaryService;
@@ -27,6 +30,7 @@ public class DailySummaryController {
 	 * @param accessToken (예: Authorization 헤더에서 추출해도 됨)
 	 */
 	@PostMapping(value = "/daily", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	@Operation(summary = "일일 요약", description = "일일 요약 페이지를 생성합니다.")
 	public Mono<ResponseEntity<SuccessResponse<DailySummaryService.DailySummaryResult>>> getDailySummary(
 		@RequestHeader(value = "Authorization", required = false) String accessToken,
 		@RequestBody TimeAnalysisRequest request) {

--- a/src/main/java/com/univ/memoir/api/controller/KeywordController.java
+++ b/src/main/java/com/univ/memoir/api/controller/KeywordController.java
@@ -4,6 +4,8 @@ import com.univ.memoir.api.dto.req.VisitedPagesRequest;
 import com.univ.memoir.api.exception.codes.SuccessCode;
 import com.univ.memoir.api.exception.responses.SuccessResponse;
 import com.univ.memoir.core.service.KeywordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,13 +16,14 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/keywords")
+@Tag(name = "오늘의 키워드", description = "오늘의 키워드 관련 API")
 public class KeywordController {
 
     private final KeywordService keywordService;
 
     @PostMapping("/analyze")
-    public
-    Mono<ResponseEntity<SuccessResponse<Map>>> analyzeKeywords(
+    @Operation(summary = "오늘의 키워드 분석", description = "오늘의 키워드를 분석합니다.")
+    public Mono<ResponseEntity<SuccessResponse<Map>>> analyzeKeywords(
             @RequestHeader("Authorization") String accessToken,
             @RequestBody VisitedPagesRequest request
     ) {

--- a/src/main/java/com/univ/memoir/api/controller/SummaryController.java
+++ b/src/main/java/com/univ/memoir/api/controller/SummaryController.java
@@ -2,6 +2,8 @@ package com.univ.memoir.api.controller;
 
 import java.time.YearMonth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,11 +21,13 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "캘린더 요약", description = "캘린더 요약 API")
 public class SummaryController {
 
 	private final MonthlySummaryService monthlySummaryService;
 
 	@GetMapping("/monthly/{date}")
+	@Operation(summary = "월별 요약 페이지", description = "월별 요약 페이지를 조회합니다.")
 	public ResponseEntity<SuccessResponse<MonthlySummaryResponse.Data>> getMonthlySummary(
 		@PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
 	) {

--- a/src/main/java/com/univ/memoir/api/controller/TimeController.java
+++ b/src/main/java/com/univ/memoir/api/controller/TimeController.java
@@ -5,6 +5,8 @@ import com.univ.memoir.api.dto.res.time.ActivityStats;
 import com.univ.memoir.api.exception.codes.SuccessCode;
 import com.univ.memoir.api.exception.responses.SuccessResponse;
 import com.univ.memoir.core.service.TimeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,11 +15,13 @@ import reactor.core.publisher.Mono;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "웹 활동 기록", description = "웹 활동기록 관련 API")
 public class TimeController {
 
     private final TimeService timeService;
 
     @PostMapping("/time")
+    @Operation(summary = "웹 활동 시간 분석", description = "웹 활동 시간을 분석합니다.")
     public Mono<ResponseEntity<SuccessResponse<ActivityStats>>> analyzeTimeStats(
             @RequestHeader("Authorization") String accessToken,
             @RequestBody TimeAnalysisRequest request

--- a/src/main/java/com/univ/memoir/api/dto/req/BookmarkRequestDto.java
+++ b/src/main/java/com/univ/memoir/api/dto/req/BookmarkRequestDto.java
@@ -1,0 +1,8 @@
+package com.univ.memoir.api.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class BookmarkRequestDto {
+    private String url;
+}

--- a/src/main/java/com/univ/memoir/api/dto/req/BookmarkUpdateRequestDto.java
+++ b/src/main/java/com/univ/memoir/api/dto/req/BookmarkUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.univ.memoir.api.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class BookmarkUpdateRequestDto {
+    private String oldUrl;
+    private String newUrl;
+}

--- a/src/main/java/com/univ/memoir/api/exception/codes/SuccessCode.java
+++ b/src/main/java/com/univ/memoir/api/exception/codes/SuccessCode.java
@@ -12,6 +12,8 @@ public enum SuccessCode {
      * 200 OK
      */
     OK(HttpStatus.OK, "요청이 성공했습니다."),
+    BOOKMARK_UPDATE_SUCCESS(HttpStatus.OK,"북마크가 수정되었습니다."),
+    BOOKMARK_RETRIEVE_SUCCESS(HttpStatus.OK,"북마크 조회에 성공했습니다."),
 
     /**
      * 201 CREATED SUCCESS
@@ -21,6 +23,7 @@ public enum SuccessCode {
     UPDATED(HttpStatus.CREATED, "업데이트 요청이 성공했습니다."),
     KEYWORD_EXTRACTION_SUCCESS(HttpStatus.CREATED, "키워드 추출에 성공했습니다."),
     TIME_ANALYSIS_SUCCESS(HttpStatus.CREATED, "사용 시간 분석에 성공했습니다."),
+    BOOKMARK_ADD_SUCCESS(HttpStatus.CREATED,"북마크가 추가되었습니다."),
 
     /**
      * 202 ACCEPTED
@@ -41,7 +44,8 @@ public enum SuccessCode {
     /**
      * 204 NO CONTENT (Deletion Responses)
      */
-    USER_DELETED(HttpStatus.NO_CONTENT, "유저가 성공적으로 삭제되었습니다.");
+    USER_DELETED(HttpStatus.NO_CONTENT, "유저가 성공적으로 삭제되었습니다."),
+    BOOKMARK_REMOVE_SUCCESS(HttpStatus.NO_CONTENT,"북마크가 삭제되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/univ/memoir/core/domain/User.java
+++ b/src/main/java/com/univ/memoir/core/domain/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -29,8 +30,8 @@ public class User {
     @Column(name = "profile_url", length = 2048)
     private String profileUrl;
 
-    @Column(name = "refresh_token")
-    private String refreshToken;
+    @Column(name = "access_token")
+    private String accessToken;
 
     @Column(length = 1, nullable = false)
     private String status = "N"; // 'N' = 정상 / 'Y' = 탈퇴
@@ -41,13 +42,22 @@ public class User {
     @Column(name = "interest")
     private Set<InterestType> interests = new HashSet<>();
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+            name = "user_bookmarks",
+            joinColumns = @JoinColumn(name = "user_id"),
+            uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "bookmark_url"})
+    )
+    @Column(name = "bookmark_url", length = 512, nullable = false)
+    private Set<String> bookmarkUrls = new HashSet<>();
+
     @Builder
-    public User(String googleId, String email, String name, String profileUrl, String refreshToken) {
+    public User(String googleId, String email, String name, String profileUrl, String accessToken) {
         this.googleId = googleId;
         this.email = email;
         this.name = name;
         this.profileUrl = profileUrl;
-        this.refreshToken = refreshToken;
+        this.accessToken = accessToken;
         this.status = "N";
     }
 
@@ -59,13 +69,9 @@ public class User {
         this.profileUrl = profileUrl;
     }
 
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
     public void withdraw() {
         this.status = "Y";
-        this.refreshToken = null;
+        this.accessToken = null;
     }
 
     public boolean isActive() {
@@ -77,5 +83,15 @@ public class User {
         this.interests.addAll(newInterests);
     }
 
+    public void addBookmarkUrl(String url) {
+        this.bookmarkUrls.add(url);
+    }
 
+    public void removeBookmarkUrl(String url) {
+        this.bookmarkUrls.remove(url);
+    }
+
+    public Set<String> getBookmarks() {
+        return bookmarkUrls;
+    }
 }

--- a/src/main/java/com/univ/memoir/core/repository/UserRepository.java
+++ b/src/main/java/com/univ/memoir/core/repository/UserRepository.java
@@ -10,9 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByGoogleId(String googleId);
 
-    Optional<User> findByRefreshToken(String refreshToken);
-
-    boolean existsByGoogleId(String GoogleId);
+    Optional<User> findByEmail(String email);
 
 }
 

--- a/src/main/java/com/univ/memoir/core/service/BookmarkService.java
+++ b/src/main/java/com/univ/memoir/core/service/BookmarkService.java
@@ -1,0 +1,62 @@
+package com.univ.memoir.core.service;
+
+import com.univ.memoir.api.dto.req.BookmarkRequestDto;
+import com.univ.memoir.api.dto.req.BookmarkUpdateRequestDto;
+import com.univ.memoir.api.exception.codes.ErrorCode;
+import com.univ.memoir.api.exception.codes.SuccessCode;
+import com.univ.memoir.api.exception.customException.InvalidTokenException;
+import com.univ.memoir.api.exception.responses.SuccessResponse;
+import com.univ.memoir.config.jwt.JwtProvider;
+import com.univ.memoir.core.domain.User;
+import com.univ.memoir.core.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional(readOnly = true)
+    public SuccessResponse<Set<String>> getBookmarks(String accessToken) {
+        String email = jwtProvider.getEmailFromToken(accessToken);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_JWT_ACCESS_TOKEN));
+
+        return SuccessResponse.of(SuccessCode.BOOKMARK_RETRIEVE_SUCCESS, user.getBookmarks()).getBody();
+    }
+
+
+    @Transactional
+    public SuccessResponse<String> addBookmark(String accessToken, BookmarkRequestDto requestDto) {
+        String email  = jwtProvider.getEmailFromToken(accessToken);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_JWT_ACCESS_TOKEN));
+        user.addBookmarkUrl(requestDto.getUrl());
+        return SuccessResponse.of(SuccessCode.BOOKMARK_ADD_SUCCESS, requestDto.getUrl()).getBody();
+    }
+
+    @Transactional
+    public SuccessResponse<String> removeBookmark(String accessToken, BookmarkRequestDto requestDto) {
+        String email  = jwtProvider.getEmailFromToken(accessToken);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_JWT_ACCESS_TOKEN));
+        user.removeBookmarkUrl(requestDto.getUrl());
+        return SuccessResponse.of(SuccessCode.BOOKMARK_REMOVE_SUCCESS, requestDto.getUrl()).getBody();
+    }
+
+    @Transactional
+    public SuccessResponse<String> updateBookmark(String accessToken, BookmarkUpdateRequestDto requestDto) {
+        String email  = jwtProvider.getEmailFromToken(accessToken);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_JWT_ACCESS_TOKEN));
+        user.removeBookmarkUrl(requestDto.getOldUrl());
+        user.addBookmarkUrl(requestDto.getNewUrl());
+        return SuccessResponse.of(SuccessCode.BOOKMARK_UPDATE_SUCCESS, requestDto.getNewUrl()).getBody();
+    }
+}


### PR DESCRIPTION
## Key Changes
* User 엔티티에 즐겨찾기(Set<String>) 컬렉션 매핑 및 중복 방지 위한 DB 유니크 제약 추가
* 즐겨찾기 추가/삭제/수정/조회 기능을 서비스와 컨트롤러에 구현
* JWT 토큰을 이용한 사용자 식별 로직 연동
* Swagger 문서에 operation과 tag 추가하여 API 명세서 가독성 및 완성도 향상

## To Reviewers
* 북마크 CRUD API 정상 동작 및 데이터 무결성 검증 부탁드립니다.
* JWT 토큰 처리 및 사용자 식별 과정에 문제 없는지 확인 바랍니다.
* Swagger 문서에 추가된 operation, tag가 적절히 작성되었는지 피드백 부탁드립니다.

## To Be Developed
* 북마크 기능에 정렬, 필터링 기능 추가 고려
* JWT 토큰 만료 시 리프레시 토큰 처리 로직 보완
* Swagger 문서 자동화 및 CI 연동 작업 진행 예정

## PR CheckList
* [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
* [x] 변경 사항에 대한 테스트를 진행했습니다.
* [x] Postman 또는 유사 도구로 API 테스트 완료했습니다.
* [x] Reviewer 추가 및 단톡방에 공유했습니다.
