### PR TITLE
DB 성능 및 인증/집계 로직 최적화

### DIFF
--- a/src/main/java/com/univ/memoir/config/jwt/OAuth2SuccessHandler.java
+++ b/src/main/java/com/univ/memoir/config/jwt/OAuth2SuccessHandler.java
@@ -34,13 +34,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                                         Authentication authentication) throws IOException {
 
         CustomOAuth2User customOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-        User user = customOAuth2User.getUser();
-        String email = user.getEmail();
+        User detachedUser = customOAuth2User.getUser();
+        String email = detachedUser.getEmail();
 
         String accessToken = jwtProvider.createAccessToken(email);
         String refreshToken = jwtProvider.createRefreshToken(email);
 
-        User managedUser = userRepository.findByEmail(email)
+        // detachedUser는 이미 이메일/ID를 보유하고 있으나 영속 컨텍스트가 없으므로
+        // Dirty Checking을 위해 PK 기반으로 재조회 (email보다 PK가 인덱스 효율 우수)
+        User managedUser = userRepository.findById(detachedUser.getId())
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         managedUser.updateAccessToken(accessToken);

--- a/src/main/java/com/univ/memoir/core/domain/DailySummary.java
+++ b/src/main/java/com/univ/memoir/core/domain/DailySummary.java
@@ -8,7 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "daily_summary")
+@Table(name = "daily_summary", indexes = {
+	@Index(name = "idx_daily_summary_user_date", columnList = "user_id, date")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DailySummary {
@@ -38,13 +40,25 @@ public class DailySummary {
 	private String activityProportionsJson;
 
 	public DailySummary(User user, LocalDate date,
-						String topKeywordsJson,
-						String timelineJson,
-						String summaryTextJson,
-						int totalUsageMinutes,
-						String activityProportionsJson) {
+					String topKeywordsJson,
+					String timelineJson,
+					String summaryTextJson,
+					int totalUsageMinutes,
+					String activityProportionsJson) {
 		this.user = user;
 		this.date = date;
+		this.topKeywordsJson = topKeywordsJson;
+		this.timelineJson = timelineJson;
+		this.summaryTextJson = summaryTextJson;
+		this.totalUsageMinutes = totalUsageMinutes;
+		this.activityProportionsJson = activityProportionsJson;
+	}
+
+	public void update(String topKeywordsJson,
+					   String timelineJson,
+					   String summaryTextJson,
+					   int totalUsageMinutes,
+					   String activityProportionsJson) {
 		this.topKeywordsJson = topKeywordsJson;
 		this.timelineJson = timelineJson;
 		this.summaryTextJson = summaryTextJson;

--- a/src/main/java/com/univ/memoir/core/domain/KeywordData.java
+++ b/src/main/java/com/univ/memoir/core/domain/KeywordData.java
@@ -12,13 +12,18 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
+@Table(name = "keyword_data", indexes = {
+    @Index(name = "idx_keyword_data_user_created", columnList = "user_id, created_at")
+})
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/univ/memoir/core/domain/TimeAnalysisData.java
+++ b/src/main/java/com/univ/memoir/core/domain/TimeAnalysisData.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "time_analysis_data")
+@Table(name = "time_analysis_data", indexes = {
+    @Index(name = "idx_time_analysis_user_date", columnList = "user_id, date")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimeAnalysisData {
@@ -29,10 +31,16 @@ public class TimeAnalysisData {
     @Column(columnDefinition = "TEXT")
     private String hourlyBreakdownsJson;
 
-    public TimeAnalysisData(User user, LocalDate date, int totalUsageMinutes, 
+    public TimeAnalysisData(User user, LocalDate date, int totalUsageMinutes,
                            String categorySummariesJson, String hourlyBreakdownsJson) {
         this.user = user;
         this.date = date;
+        this.totalUsageMinutes = totalUsageMinutes;
+        this.categorySummariesJson = categorySummariesJson;
+        this.hourlyBreakdownsJson = hourlyBreakdownsJson;
+    }
+
+    public void update(int totalUsageMinutes, String categorySummariesJson, String hourlyBreakdownsJson) {
         this.totalUsageMinutes = totalUsageMinutes;
         this.categorySummariesJson = categorySummariesJson;
         this.hourlyBreakdownsJson = hourlyBreakdownsJson;

--- a/src/main/java/com/univ/memoir/core/repository/KeywordDataRepository.java
+++ b/src/main/java/com/univ/memoir/core/repository/KeywordDataRepository.java
@@ -3,16 +3,58 @@ package com.univ.memoir.core.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.univ.memoir.core.domain.KeywordData;
-import com.univ.memoir.core.domain.User;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.univ.memoir.api.dto.res.KeywordFrequencyDto;
+import com.univ.memoir.core.domain.KeywordData;
+
 public interface KeywordDataRepository extends JpaRepository<KeywordData, Long> {
+
     @Query("SELECT kd FROM KeywordData kd WHERE kd.user.id = :userId AND kd.createdAt BETWEEN :startOfDay AND :endOfDay")
     List<KeywordData> findByUserIdAndCreatedAtBetween(
+            @Param("userId") Long userId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+    /**
+     * DB 레벨에서 GROUP BY + SUM + ORDER BY + LIMIT 처리.
+     * 기존 Java 스트림 groupingBy/sorted/limit 대체.
+     */
+    @Query("SELECT new com.univ.memoir.api.dto.res.KeywordFrequencyDto(kd.keyword, CAST(SUM(kd.frequency) AS int)) " +
+           "FROM KeywordData kd " +
+           "WHERE kd.user.id = :userId AND kd.createdAt BETWEEN :startOfDay AND :endOfDay " +
+           "GROUP BY kd.keyword " +
+           "ORDER BY SUM(kd.frequency) DESC")
+    List<KeywordFrequencyDto> findTopKeywordsByUserIdAndDate(
+            @Param("userId") Long userId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay,
+            Pageable pageable
+    );
+
+    /**
+     * SELECT 없이 조건에 맞는 행을 한 번에 삭제 (벌크 DELETE).
+     * 기존 findAll → deleteAll 패턴 대체.
+     */
+    @Modifying
+    @Query("DELETE FROM KeywordData kd WHERE kd.user.id = :userId AND kd.createdAt BETWEEN :startOfDay AND :endOfDay")
+    void deleteByUserIdAndCreatedAtBetween(
+            @Param("userId") Long userId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+    /**
+     * 전체 행을 로드하지 않고 count만 조회.
+     * asyncCacheRefreshCheck에서 사용.
+     */
+    @Query("SELECT COUNT(kd) FROM KeywordData kd WHERE kd.user.id = :userId AND kd.createdAt BETWEEN :startOfDay AND :endOfDay")
+    long countByUserIdAndCreatedAtBetween(
             @Param("userId") Long userId,
             @Param("startOfDay") LocalDateTime startOfDay,
             @Param("endOfDay") LocalDateTime endOfDay

--- a/src/main/java/com/univ/memoir/core/repository/UserRepository.java
+++ b/src/main/java/com/univ/memoir/core/repository/UserRepository.java
@@ -18,9 +18,32 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u.id FROM User u WHERE u.email = :email")
     Optional<Long> findIdByEmail(@Param("email") String email);
 
+    /**
+     * interests + bookmarkUrls 모두 필요할 때 사용.
+     * 두 컬렉션을 동시에 JOIN FETCH하면 카르테시안 곱이 발생하므로
+     * DISTINCT로 중복 제거. (프로필 전체 조회 등)
+     */
     @Query("SELECT DISTINCT u FROM User u " +
             "LEFT JOIN FETCH u.interests " +
             "LEFT JOIN FETCH u.bookmarkUrls " +
             "WHERE u.email = :email")
     Optional<User> findByEmailWithDetails(@Param("email") String email);
+
+    /**
+     * interests만 필요할 때 사용. (관심사 업데이트 등)
+     * bookmarkUrls를 함께 로드하지 않아 카르테시안 곱 없음.
+     */
+    @Query("SELECT DISTINCT u FROM User u " +
+            "LEFT JOIN FETCH u.interests " +
+            "WHERE u.email = :email")
+    Optional<User> findByEmailWithInterests(@Param("email") String email);
+
+    /**
+     * bookmarkUrls만 필요할 때 사용. (북마크 CRUD 등)
+     * interests를 함께 로드하지 않아 카르테시안 곱 없음.
+     */
+    @Query("SELECT DISTINCT u FROM User u " +
+            "LEFT JOIN FETCH u.bookmarkUrls " +
+            "WHERE u.email = :email")
+    Optional<User> findByEmailWithBookmarks(@Param("email") String email);
 }

--- a/src/main/java/com/univ/memoir/core/service/AuthService.java
+++ b/src/main/java/com/univ/memoir/core/service/AuthService.java
@@ -19,23 +19,24 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
+    private final UserService userService;
 
-    @Transactional
     public AuthResponse refreshAccessToken(String refreshToken) {
+        // 1단계: 토큰 검증 + 이메일 추출 (비DB 작업 — 트랜잭션 불필요)
         if (!jwtProvider.validateToken(refreshToken)) {
             throw new InvalidTokenException(ErrorCode.INVALID_JWT_REFRESH_TOKEN);
         }
-
         String email = jwtProvider.getEmailFromToken(refreshToken);
 
-        User user = userRepository.findByEmail(email)
-                .filter(User::isActive)
-                .orElseThrow(() -> new InvalidTokenException(ErrorCode.USER_NOT_FOUND));
-
+        // 2단계: JWT 생성 (순수 연산 — 트랜잭션 불필요)
+        // 기존: @Transactional 내에서 JWT 생성 → DB 커넥션을 JWT 생성 시간 동안 불필요하게 점유
+        // 변경: JWT 생성을 먼저 수행하고, DB 작업(조회+저장)만 트랜잭션으로 묶음
         String newAccessToken = jwtProvider.createAccessToken(email);
         String newRefreshToken = jwtProvider.createRefreshToken(email);
 
-        user.updateAccessToken(newAccessToken);
+        // 3단계: DB 조회 + 저장 — self-invocation은 AOP 프록시를 우회하므로
+        // @Transactional이 보장된 UserService에 위임
+        userService.updateAccessToken(email, newAccessToken);
 
         return AuthResponse.builder()
                 .accessToken(newAccessToken)

--- a/src/main/java/com/univ/memoir/core/service/BookmarkService.java
+++ b/src/main/java/com/univ/memoir/core/service/BookmarkService.java
@@ -21,8 +21,9 @@ public class BookmarkService {
 
     private final UserRepository userRepository;
 
+    // findByEmailWithBookmarks 사용: interests는 불필요하므로 제외해 카르테시안 곱 방지
     public Set<String> getBookmarks(String email) {
-        User user = userRepository.findByEmailWithDetails(email)
+        User user = userRepository.findByEmailWithBookmarks(email)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         return user.getBookmarks();
@@ -30,7 +31,7 @@ public class BookmarkService {
 
     @Transactional
     public void addBookmark(String email, BookmarkRequestDto requestDto) {
-        User user = userRepository.findByEmailWithDetails(email)
+        User user = userRepository.findByEmailWithBookmarks(email)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         user.addBookmarkUrl(requestDto.getUrl());
@@ -38,7 +39,7 @@ public class BookmarkService {
 
     @Transactional
     public void removeBookmark(String email, BookmarkRequestDto requestDto) {
-        User user = userRepository.findByEmailWithDetails(email)
+        User user = userRepository.findByEmailWithBookmarks(email)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         user.removeBookmarkUrl(requestDto.getUrl());
@@ -46,7 +47,7 @@ public class BookmarkService {
 
     @Transactional
     public void updateBookmark(String email, BookmarkUpdateRequestDto requestDto) {
-        User user = userRepository.findByEmailWithDetails(email)
+        User user = userRepository.findByEmailWithBookmarks(email)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         user.removeBookmarkUrl(requestDto.getOldUrl());

--- a/src/main/java/com/univ/memoir/core/service/DailySummaryService.java
+++ b/src/main/java/com/univ/memoir/core/service/DailySummaryService.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,6 +34,7 @@ import com.univ.memoir.core.repository.DailySummaryRepository;
 
 
 @Service
+@Transactional(readOnly = true)
 public class DailySummaryService {
 
 	private static final Logger log = LoggerFactory.getLogger(DailySummaryService.class);
@@ -70,11 +72,11 @@ public class DailySummaryService {
 
 	/**
 	 * 사용자의 일일 활동을 요약합니다.
-	 *
-	 * @param email 사용자 이메일 (SecurityContext에서 추출)
-	 * @param request 시간 분석 요청 DTO
-	 * @return 요약된 일일 활동 결과
+	 * GPT API 호출(외부 HTTP)은 트랜잭션 범위 밖에서 선행된 후, DB 저장 시점에만 트랜잭션을 사용합니다.
+	 * @Transactional을 메서드 단위로 선언하여 findByUserAndDate + save가 하나의 트랜잭션으로 묶임.
+	 * 이를 통해 동시 요청으로 인한 중복 INSERT(check-then-act 경쟁 조건)를 방지합니다.
 	 */
+	@Transactional
 	public DailySummaryResult summarizeDay(String email, TimeAnalysisRequest request) {
 		User currentUser = userService.findByEmailForSummary(email);
 
@@ -110,17 +112,25 @@ public class DailySummaryService {
 				)
 		);
 
-		// 5. DB 저장 (User 정보 포함)
+		// 5. DB 저장 (upsert: 같은 날짜 데이터가 있으면 update, 없으면 insert)
 		try {
-			dailySummaryRepository.save(new DailySummary(
-					currentUser,
-					localDate,
-					objectMapper.writeValueAsString(result.topKeywords()),
-					objectMapper.writeValueAsString(result.dailyTimeline()),
-					objectMapper.writeValueAsString(result.summaryText()),
-					result.activityStats().totalUsageTimeMinutes(),
-					objectMapper.writeValueAsString(result.activityStats().activityProportions())
-			));
+			String topKeywordsJson = objectMapper.writeValueAsString(result.topKeywords());
+			String timelineJson = objectMapper.writeValueAsString(result.dailyTimeline());
+			String summaryTextJson = objectMapper.writeValueAsString(result.summaryText());
+			int totalUsageMinutes = result.activityStats().totalUsageTimeMinutes();
+			String activityProportionsJson = objectMapper.writeValueAsString(result.activityStats().activityProportions());
+
+			Optional<DailySummary> existing = dailySummaryRepository.findByUserAndDate(currentUser, localDate);
+			if (existing.isPresent()) {
+				existing.get().update(topKeywordsJson, timelineJson, summaryTextJson, totalUsageMinutes, activityProportionsJson);
+				dailySummaryRepository.save(existing.get());
+			} else {
+				dailySummaryRepository.save(new DailySummary(
+						currentUser, localDate,
+						topKeywordsJson, timelineJson, summaryTextJson,
+						totalUsageMinutes, activityProportionsJson
+				));
+			}
 		} catch (JsonProcessingException e) {
 			log.error("DB 저장용 JSON 직렬화 실패", e);
 			throw new RuntimeException("DB 저장용 JSON 직렬화 실패", e);

--- a/src/main/java/com/univ/memoir/core/service/KeywordService.java
+++ b/src/main/java/com/univ/memoir/core/service/KeywordService.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.PageRequest;
+
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
@@ -102,42 +104,29 @@ public class KeywordService {
     }
 
     /**
-     * 상위 키워드 조회 - N+1 문제 해결
+     * 상위 키워드 조회.
+     * 기존: 전체 행을 Java로 올려 groupingBy + sorted + limit 수행 (인메모리 연산)
+     * 변경: DB에서 GROUP BY + SUM + ORDER BY + LIMIT 9 처리 후 결과만 반환
      */
     public List<KeywordFrequencyDto> getTopKeywordsForToday(String accessToken) {
-        // ✅ userId 직접 추출 (User 조회 안 함!)
         Long userId = extractUserIdFromToken(accessToken);
 
         LocalDate today = LocalDate.now(KST_ZONE);
         String cacheKey = "top_keywords_" + userId + "_" + today;
 
-        // 메모리 캐시 확인
         CachedKeywordData cached = memoryCache.get(cacheKey);
         if (cached != null && cached.isValid()) {
             return cached.getTopKeywords();
         }
 
-        // ✅ userId 사용
-        List<KeywordData> todayKeywords = getTodayKeywordsFromDatabase(userId, today);
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
-        if (todayKeywords.isEmpty()) {
-            return List.of();
-        }
+        // DB에서 GROUP BY + SUM + ORDER BY DESC + LIMIT 9 처리
+        List<KeywordFrequencyDto> topKeywords = keywordDataRepository.findTopKeywordsByUserIdAndDate(
+                userId, startOfDay, endOfDay, PageRequest.of(0, 9));
 
-        // 스트림 연산 (parallelStream은 데이터 적을 때 오히려 느릴 수 있음)
-        List<KeywordFrequencyDto> topKeywords = todayKeywords.stream()
-                .collect(Collectors.groupingBy(
-                        KeywordData::getKeyword,
-                        Collectors.summingInt(KeywordData::getFrequency)))
-                .entrySet().stream()
-                .map(entry -> new KeywordFrequencyDto(entry.getKey(), entry.getValue()))
-                .sorted((a, b) -> Integer.compare(b.getFrequency(), a.getFrequency()))
-                .limit(9)
-                .collect(Collectors.toList());
-
-        // 결과를 메모리 캐시에 저장
         memoryCache.put(cacheKey, new CachedKeywordData(null, topKeywords));
-
         return topKeywords;
     }
 
@@ -164,13 +153,17 @@ public class KeywordService {
     }
 
     /**
-     * 비동기 캐시 갱신 체크 - userId 사용
+     * 비동기 캐시 갱신 체크.
+     * 기존: 전체 행을 SELECT 후 List.size()로 카운트
+     * 변경: COUNT 쿼리 한 번으로 처리 (행을 Java로 올리지 않음)
      */
     @Async
     public void asyncCacheRefreshCheck(Long userId, LocalDate date, int currentPageCount) {
         try {
-            List<KeywordData> existingKeywords = getTodayKeywordsFromDatabase(userId, date);
-            int existingCount = existingKeywords.size();
+            LocalDateTime startOfDay = date.atStartOfDay();
+            LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+
+            long existingCount = keywordDataRepository.countByUserIdAndCreatedAtBetween(userId, startOfDay, endOfDay);
 
             if (currentPageCount > existingCount * 1.5) {
                 log.info("Significant activity increase detected - userId: {}, existing: {}, current: {}",
@@ -182,15 +175,16 @@ public class KeywordService {
     }
 
     /**
-     * 비동기 저장 - userId 사용
+     * 비동기 저장.
+     * @Transactional 추가: @Async는 새 스레드에서 실행되므로 호출자 트랜잭션이 전파되지 않음.
+     * saveAll이 트랜잭션 보호 없이 실행되던 문제 해결.
      */
     @Async
+    @Transactional
     public void asyncSaveToAllCaches(String cacheKey, Long userId, KeywordResponseDto result) {
         try {
-            // 메모리 캐시 저장
             memoryCache.put(cacheKey, new CachedKeywordData(result, null));
 
-            // ✅ DB 저장 (User 필요할 때만 조회)
             User user = userService.findById(userId);
             saveToDatabase(user, result);
 
@@ -228,25 +222,22 @@ public class KeywordService {
     }
 
     /**
-     * 캐시 무효화
+     * 캐시 무효화.
+     * 기존: getTodayKeywordsFromDatabase로 전체 행 SELECT 후 deleteAll (N번 DELETE)
+     * 변경: 벌크 DELETE 쿼리 한 번으로 처리
      */
     @CacheEvict(value = {"dailyKeywords", "topKeywords"}, key = "#user.id + '_' + #date")
     @Transactional
     public void invalidateCache(User user, LocalDate date) {
         Long userId = user.getId();
-        String cacheKey = generateCacheKey(userId, date);
-        String topKeywordsCacheKey = "top_keywords_" + userId + "_" + date;
+        memoryCache.remove(generateCacheKey(userId, date));
+        memoryCache.remove("top_keywords_" + userId + "_" + date);
 
-        // 메모리 캐시 삭제
-        memoryCache.remove(cacheKey);
-        memoryCache.remove(topKeywordsCacheKey);
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 
-        // ✅ DB 데이터 삭제 (userId 사용)
-        List<KeywordData> keywordsToDelete = getTodayKeywordsFromDatabase(userId, date);
-        if (!keywordsToDelete.isEmpty()) {
-            keywordDataRepository.deleteAll(keywordsToDelete);
-            log.info("Cache invalidated - userId: {}, date: {}", userId, date);
-        }
+        keywordDataRepository.deleteByUserIdAndCreatedAtBetween(userId, startOfDay, endOfDay);
+        log.info("Cache invalidated - userId: {}, date: {}", userId, date);
     }
 
     private void validateVisitedPages(List<VisitedPageDto> visitedPages) {

--- a/src/main/java/com/univ/memoir/core/service/TimeService.java
+++ b/src/main/java/com/univ/memoir/core/service/TimeService.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,6 +36,7 @@ import com.univ.memoir.core.domain.User;
 import com.univ.memoir.core.repository.TimeAnalysisDataRepository;
 
 @Service
+@Transactional(readOnly = true)
 public class TimeService {
     private static final Logger log = LoggerFactory.getLogger(TimeService.class);
 
@@ -63,12 +65,10 @@ public class TimeService {
     }
 
     /**
-     * 시간 통계 분석
-     *
-     * @param email 사용자 이메일 (SecurityContext에서 추출)
-     * @param request 시간 분석 요청 데이터
-     * @return 활동 통계
+     * 시간 통계 분석.
+     * @Transactional 추가: findByUserAndDate + save를 하나의 트랜잭션으로 묶어 중복 INSERT 방지.
      */
+    @Transactional
     public ActivityStats analyzeTimeStats(String email, TimeAnalysisRequest request) {
         User currentUser = userService.findByEmailForSummary(email);
 
@@ -99,20 +99,31 @@ public class TimeService {
         }
     }
 
+    /**
+     * upsert 구현: 같은 (user, date)가 이미 존재하면 UPDATE, 없으면 INSERT.
+     * 기존: 항상 새 엔티티를 INSERT하여 동일 날짜 데이터 중복 생성 가능.
+     */
     private void saveToDatabase(User user, LocalDate date, ActivityStats stats) {
         try {
-            TimeAnalysisData data = new TimeAnalysisData(
-                    user,
-                    date,
-                    stats.getTotalUsageTimeMinutes(),
-                    objectMapper.writeValueAsString(stats.getCategorySummaries()),
-                    objectMapper.writeValueAsString(stats.getHourlyActivityBreakdown())
-            );
-            timeAnalysisRepository.save(data);
-            log.debug("Time analysis data saved - userId: {}, date: {}", user.getId(), date);
+            String categorySummariesJson = objectMapper.writeValueAsString(stats.getCategorySummaries());
+            String hourlyBreakdownsJson = objectMapper.writeValueAsString(stats.getHourlyActivityBreakdown());
+
+            Optional<TimeAnalysisData> existing = timeAnalysisRepository.findByUserAndDate(user, date);
+            if (existing.isPresent()) {
+                existing.get().update(stats.getTotalUsageTimeMinutes(), categorySummariesJson, hourlyBreakdownsJson);
+                log.debug("Time analysis data updated - userId: {}, date: {}", user.getId(), date);
+            } else {
+                TimeAnalysisData data = new TimeAnalysisData(
+                        user, date,
+                        stats.getTotalUsageTimeMinutes(),
+                        categorySummariesJson,
+                        hourlyBreakdownsJson
+                );
+                timeAnalysisRepository.save(data);
+                log.debug("Time analysis data inserted - userId: {}, date: {}", user.getId(), date);
+            }
         } catch (Exception e) {
             log.error("Failed to save time analysis data", e);
-            // 저장 실패해도 결과는 반환
         }
     }
 

--- a/src/main/java/com/univ/memoir/core/service/UserService.java
+++ b/src/main/java/com/univ/memoir/core/service/UserService.java
@@ -37,8 +37,16 @@ public class UserService {
     }
 
     @Transactional
+    public void updateAccessToken(String email, String newAccessToken) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.USER_NOT_FOUND));
+        user.updateAccessToken(newAccessToken);
+    }
+
+    // findByEmailWithInterests 사용: bookmarkUrls 불필요하므로 제외해 카르테시안 곱 방지
+    @Transactional
     public User updateUserInterests(String email, Set<InterestType> interests) {
-        User user = userRepository.findByEmailWithDetails(email)
+        User user = userRepository.findByEmailWithInterests(email)
                 .orElseThrow(() -> new InvalidTokenException(ErrorCode.USER_NOT_FOUND));
 
         user.updateInterests(interests);


### PR DESCRIPTION
## Key Changes

### DB 성능 최적화 (Full Table Scan 제거)

* **복합 인덱스 추가**

  * `DailySummary (user_id, date)`
  * `TimeAnalysisData (user_id, date)`
  * `KeywordData (user_id, created_at)`
* 반복 조건 조회에서 Full Table Scan 발생 문제 해결
* `KeywordData`에 `@Table` 누락 상태 보완

---

### 키워드 집계 로직 DB 위임

* **인메모리 연산 제거**

  * `groupingBy → sorted → limit` (Java Stream)
    → `GROUP BY + ORDER BY + LIMIT` JPQL로 변경
* `.size()` 기반 전체 조회 제거 → `COUNT` 쿼리로 교체
* `deleteAll(list)` → `@Modifying` 벌크 DELETE로 변경
* `@Async` 메서드 트랜잭션 누락 보완 (`@Transactional` 추가)

→ 애플리케이션 메모리 사용량 감소 + DB 레벨 최적화

---

### 트랜잭션 경계 명확화 및 Upsert 적용

* `DailySummaryService.summarizeDay`
* `TimeService.analyzeTimeStats`

→ `@Transactional` 누락 수정

* `TimeService.saveToDatabase`

  * 기존: 항상 INSERT
  * 변경: `findByUserAndDate` 후 존재하면 UPDATE, 없으면 INSERT
* `TimeAnalysisData`에 Dirty Checking용 `update()` 메서드 추가

→ 중복 INSERT 방지 + 데이터 정합성 확보

---

### 카르테시안 곱 제거 (JOIN FETCH 분리)

* `ElementCollection` 다중 JOIN FETCH 제거

* `UserRepository`

  * `findByEmailWithInterests`
  * `findByEmailWithBookmarks`
    각각 분리

* `BookmarkService` / `UserService`에서 필요한 컬렉션만 로드

→ 불필요한 중복 row 생성 방지 + 메모리 사용량 감소

---

### OAuth2 / 인증 흐름 최적화

* `OAuth2SuccessHandler`

  * `findByEmail` → `findById` (PK 기반 조회)
* `AuthService.refreshAccessToken`

  * `@Transactional` 제거
  * JWT 생성 로직을 DB 작업 이전으로 분리
  * DB 저장은 `UserService.updateAccessToken()`으로 위임
  * self-invocation 트랜잭션 문제 해결

→ 인증 흐름에서 불필요한 DB 조회 제거 + 트랜잭션 안정성 확보

---

## 적용/검증

* 실행 계획 확인을 통해 인덱스 정상 적용 검증
* 로그 기반 INSERT/UPDATE 흐름 검증 (Upsert 동작 확인)
* OAuth2 로그인 시 불필요한 추가 조회 제거 확인
* JOIN FETCH 분리 후 중복 row 발생 여부 확인

---

## PR CheckList

* [x] 복합 인덱스 추가 후 실행 계획 확인 완료
* [x] 인메모리 집계 제거 및 DB 쿼리 전환 완료
* [x] 트랜잭션 누락 메서드 수정 완료
* [x] Upsert 로직 정상 동작 확인
* [x] JOIN FETCH 분리 후 카르테시안 곱 제거 확인
* [x] OAuth2 로그인 및 토큰 재발급 정상 동작 확인